### PR TITLE
Add support for registration of discovered SPI PersistenceProvider

### DIFF
--- a/pax-jpa-tck/tck.bndrun
+++ b/pax-jpa-tck/tck.bndrun
@@ -1,7 +1,8 @@
 -runtrace: true
 
 -runproperties = \
-    report='true'
+    report='true', \
+    pax.jpa.registerSpiProviderAsService=true
     
 -runstartlevel: \
     order=sortbynameversion,\

--- a/pax-jpa/src/main/java/org/ops4j/pax/jpa/impl/PersistenceProviderBundle.java
+++ b/pax-jpa/src/main/java/org/ops4j/pax/jpa/impl/PersistenceProviderBundle.java
@@ -30,7 +30,11 @@ import java.util.Map.Entry;
 
 import javax.persistence.spi.PersistenceProvider;
 
+import org.ops4j.pax.jpa.JpaConstants;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,21 +47,30 @@ import org.slf4j.LoggerFactory;
  */
 public class PersistenceProviderBundle {
 
+	// This is mostly to support the TCK that require this, but maybe also useful for others, see https://github.com/osgi/osgi/issues/734
+	private static final boolean REGISTER_PROVIDER_AS_SERVICE = Boolean.getBoolean("pax.jpa.registerSpiProviderAsService");
+
 	private static Logger LOG = LoggerFactory.getLogger(PersistenceProviderBundle.class);
 
-	private Map<String, PersistenceProvider> providers;
+	private final Map<String, PersistenceProvider> providers;
 
-	private Bundle bundle;
+	private final Bundle bundle;
 
-	private List<EntityManagerFactoryBuilderImpl> assignedFactories = new ArrayList<>();
+	private final List<EntityManagerFactoryBuilderImpl> assignedFactories = new ArrayList<>();
+	private List<ServiceRegistration<PersistenceProvider>> registrations;
 
 	public PersistenceProviderBundle(Bundle bundle, Map<String, PersistenceProvider> provider) {
 		this.bundle = bundle;
 		this.providers = new LinkedHashMap<>(provider);
+		update();
 	}
 
 	public synchronized void shutdown() {
-		for (EntityManagerFactoryBuilderImpl factoryBuilderImpl : assignedFactories) {
+		if(registrations != null) {
+			registrations.forEach(ServiceRegistration::unregister);
+			registrations = null;
+		}
+		for(EntityManagerFactoryBuilderImpl factoryBuilderImpl : assignedFactories) {
 			factoryBuilderImpl.assignProvider(null);
 		}
 		assignedFactories.clear();
@@ -67,13 +80,11 @@ public class PersistenceProviderBundle {
 	public synchronized boolean assignTo(EntityManagerFactoryBuilderImpl factoryBuilder) {
 
 		String providerClassName = factoryBuilder.getPersistenceProviderClassName();
-		for (Entry<String, PersistenceProvider> entry : providers.entrySet()) {
+		for(Entry<String, PersistenceProvider> entry : providers.entrySet()) {
 			PersistenceProvider persistenceProvider = entry.getValue();
-			if (providerClassName == null || providerClassName.equals(entry.getKey())
-					|| providerClassName.equals(persistenceProvider.getClass().getName())) {
-				LOG.info("assign persistence provider {} from bundle {} to persistence unit {}",
-						new Object[] { persistenceProvider.getClass().getName(), PaxJPA.getBundleName(bundle),
-								factoryBuilder.getPersistenceUnitInfo().getPersistenceUnitName() });
+			if(providerClassName == null || providerClassName.equals(entry.getKey()) || providerClassName.equals(persistenceProvider.getClass().getName())) {
+				LOG.info("assign persistence provider {} from bundle {} to persistence unit {}", new Object[]{persistenceProvider.getClass().getName(), PaxJPA
+						.getBundleName(bundle), factoryBuilder.getPersistenceUnitInfo().getPersistenceUnitName()});
 				assignedFactories.add(factoryBuilder);
 				factoryBuilder.assignProvider(entry.getValue());
 				return true;
@@ -84,5 +95,23 @@ public class PersistenceProviderBundle {
 
 	public Collection<PersistenceProvider> getProviders() {
 		return Collections.unmodifiableCollection(providers.values());
+	}
+
+	public synchronized void update() {
+		if(REGISTER_PROVIDER_AS_SERVICE) {
+			BundleContext bundleContext = bundle.getBundleContext();
+			if(bundleContext == null) {
+				if(registrations != null) {
+					registrations.forEach(ServiceRegistration::unregister);
+					registrations = null;
+				}
+			} else if(registrations == null) {
+				registrations = providers.values()
+						.stream()
+						.map(provider -> bundleContext
+								.registerService(PersistenceProvider.class, provider, FrameworkUtil.asDictionary(Map.of(JpaConstants.JPA_PROVIDER, provider.getClass().getName()))))
+						.toList();
+			}
+		}
 	}
 }

--- a/pax-jpa/src/main/java/org/ops4j/pax/jpa/impl/tracker/PersistenceProviderBundleTrackerCustomizer.java
+++ b/pax-jpa/src/main/java/org/ops4j/pax/jpa/impl/tracker/PersistenceProviderBundleTrackerCustomizer.java
@@ -64,7 +64,7 @@ public class PersistenceProviderBundleTrackerCustomizer implements BundleTracker
 			Iterator<PersistenceProvider> iterator = serviceLoader.iterator();
 			Map<String, PersistenceProvider> list = new LinkedHashMap<>();
 			while (iterator.hasNext()) {
-				PersistenceProvider persistenceProvider = (PersistenceProvider) iterator.next();
+				PersistenceProvider persistenceProvider = iterator.next();
 				LOG.debug("loaded PersistenceProvider {} from bundle {}", persistenceProvider.getClass().getName(), bundleName);
 				list.put(persistenceProvider.getClass().getName(), persistenceProvider);
 			}
@@ -79,6 +79,7 @@ public class PersistenceProviderBundleTrackerCustomizer implements BundleTracker
 	public void modifiedBundle(Bundle bundle, BundleEvent event, PersistenceProviderBundle providerBundle) {
 
 		// nothing to do here
+		providerBundle.update();
 	}
 
 	@Override


### PR DESCRIPTION
Currently the OSGi TCK requires that PersistenceProviders are registered as a service (see https://github.com/osgi/osgi/issues/734 ).

Even though PaxJPA does not require this as it includes an own extender, we can offer an option to register discovered providers as services to make the TCK pass in this case.